### PR TITLE
tmf: Handle multiple jobs when updating statistics

### DIFF
--- a/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/statistics/TmfStatisticsViewer.java
+++ b/tmf/org.eclipse.tracecompass.tmf.ui/src/org/eclipse/tracecompass/internal/tmf/ui/viewers/statistics/TmfStatisticsViewer.java
@@ -728,8 +728,10 @@ public class TmfStatisticsViewer extends TmfViewer {
                 /* No statistics module available for this trace */
                 continue;
             }
-
-            updateJobs.computeIfAbsent(aTrace, k -> {
+            updateJobs.compute(aTrace, (k, v) -> {
+                if (v != null) {
+                    v.cancel(); /* Cancel previous job */
+                }
                 Job job = new StatisticsUpdateJob("Statistics update", aTrace, isGlobal, timeRange, statsMod, this); //$NON-NLS-1$
                 job.setSystem(true);
                 job.schedule();


### PR DESCRIPTION
When one job is already scheduled, the previous logic did not create another job preventing subsequent selection from updating the UI in the statistics view. This commit always computes a new job and cancels the previous one if present.

[Change-Id: I14c99c6eac40def82338ca9341031951a4703db4](https://git.eclipse.org/r/c/tracecompass/org.eclipse.tracecompass/+/206051)